### PR TITLE
Fix the link to the Travis build page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Webmention.io
 
-![travis](https://travis-ci.org/aaronpk/webmention.io.svg)
+[![Travis build status](https://travis-ci.org/aaronpk/webmention.io.svg)](https://travis-ci.org/aaronpk/webmention.io)
 
 This project is an implementation of the [Webmention](https://indieweb.org/webmention) and [Pingback](https://indieweb.org/pingback) protocols. It allows the receiving service to be run separately from the blogging software or website environment, making it easier to manage and integrate with other services.
 


### PR DESCRIPTION
The link just went to the build status *image* before, not the actual status page.