### PR TITLE
Fix Atom support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,39 @@ You can use the `since` or `since_id` parameters to find new mentions retrieved 
 The API also supports JSONP so you can use it to show pingbacks on your own sites via Javascript. Simply add a parameter `jsonp` to the API call, for example, http://webmention.io/api/mentions?jsonp=f&target=http%3A%2F%2Fwebmention.io
 
 
+### Atom
+
+You can change `/mentions` to `/mentions.atom` to receive your results in the [Atom] format:
+
+[Atom]: https://en.wikipedia.org/wiki/Atom_(Web_standard)
+
+```
+GET https://webmention.io/api/mentions.atom?token=xxxxxx
+
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>https://webmention.io/api/mentions.atom</id>
+  <title>Mentions</title>
+  <updated>2013-04-25T17:09:33-07:00</updated>
+  <link href="https://webmention.io/api/mentions.atom"/>
+  <author>
+    <name>webmention.io</name>
+  </author>
+  <entry>
+    <title>tantek.com mentioned /webmention</title>
+    <id>https://webmention.io/api/mention/8675309</id>
+    <summary>http://tantek.com/2013/113/b1/first-federated-indieweb-comment-thread mentioned http://indiewebcamp.com/webmention</summary>
+    <updated>2013-04-25T17:09:33-07:00</updated>
+    <content type="xhtml" xml:lang="en">
+      <div xmlns="http://www.w3.org/1999/xhtml">
+        <p><a href="http://tantek.com/2013/113/b1/first-federated-indieweb-comment-thread">http://tantek.com/2013/113/b1/first-federated-indieweb-comment-thread</a> mentioned <a href="http://indiewebcamp.com/webmention">http://indiewebcamp.com/webmention</a></p>
+      </div>
+    </content>
+  </entry>
+</feed>
+```
+
+
 ## Notifications
 
 ### IRC

--- a/controllers/api.rb
+++ b/controllers/api.rb
@@ -178,30 +178,9 @@ class Controller < Sinatra::Base
     if format == 'json'
       api_response format, 200, Formats.links_to_json(links)
     elsif format =='jf2'
-      api_response 'json', 200, Formats.links_to_jf2(links)
+      api_response format, 200, Formats.links_to_jf2(links)
     else
-      base_url = "https://webmention.io"
-      atom_url = "#{base_url}/api/mentions.atom"
-      feed = Atom::Feed.new{|f|
-        f.title = "Mentions"
-        f.links << Atom::Link.new(:href => atom_url)
-        f.updated = link_array.collect{|l| l[:verified_date]}.max
-        f.authors << Atom::Person.new(:name => "webmention.io")
-        f.id = atom_url
-        link_array.each do |link|
-          source = URI.parse link[:source]
-          target = URI.parse link[:target]
-          target.path = "/" if target.path == ""
-          f.entries << Atom::Entry.new do |entry|
-            entry.title = "#{source.host} linked to #{target.path}"
-            entry.id = "#{base_url}/api/mention/#{link[:id]}"
-            entry.updated = link[:verified_date]
-            entry.summary = "#{link[:source]} linked to #{link[:target]}"
-            entry.content = Atom::Content::Xhtml.new("<p><a href=\"#{link[:source]}\">#{link[:source]}</a> linked to <a href=\"#{link[:target]}\">#{link[:target]}</a></p>")
-          end
-        end
-      }
-      api_response format, 200, feed.to_xml
+      api_response format, 200, Formats.links_to_atom(links)
     end
   end
 

--- a/helpers/formats.rb
+++ b/helpers/formats.rb
@@ -196,4 +196,29 @@ class Formats
     jf2
   end
 
+  def self.links_to_atom(links)
+    base_url = "https://webmention.io"
+    atom_url = "#{base_url}/api/mentions.atom"
+    feed = Atom::Feed.new{|f|
+      f.title = "Mentions"
+      f.links << Atom::Link.new(:href => atom_url)
+      f.updated = link_array.collect{|l| l[:verified_date]}.max
+      f.authors << Atom::Person.new(:name => "webmention.io")
+      f.id = atom_url
+      link_array.each do |link|
+        source = URI.parse link[:source]
+        target = URI.parse link[:target]
+        target.path = "/" if target.path == ""
+        f.entries << Atom::Entry.new do |entry|
+          entry.title = "#{source.host} linked to #{target.path}"
+          entry.id = "#{base_url}/api/mention/#{link[:id]}"
+          entry.updated = link[:verified_date]
+          entry.summary = "#{link[:source]} linked to #{link[:target]}"
+          entry.content = Atom::Content::Xhtml.new("<p><a href=\"#{link[:source]}\">#{link[:source]}</a> linked to <a href=\"#{link[:target]}\">#{link[:target]}</a></p>")
+        end
+      end
+    }
+    feed.to_xml
+  end
+
 end

--- a/helpers/formats.rb
+++ b/helpers/formats.rb
@@ -196,6 +196,29 @@ class Formats
     jf2
   end
 
+  def self.english_description(type)
+    case type
+    when "like"
+      "liked"
+    when "repost"
+      "reposted"
+    when "reply"
+      "replied to"
+    when "bookmark"
+      "bookmarked"
+    when "rsvp-yes"
+      "RSVPed “yes” to"
+    when "rsvp-no"
+      "RSVPed “no” to"
+    when "rsvp-maybe"
+      "RSVPed “maybe” to"
+    when "rsvp-interested"
+      "RSVPed “interested” to"
+    else
+      "mentioned"
+    end
+  end
+
   def self.links_to_atom(links)
     base_url = "https://webmention.io"
     atom_url = "#{base_url}/api/mentions.atom"
@@ -213,14 +236,16 @@ class Formats
         target.path = "/" if target.path == ""
 
         f.entries << Atom::Entry.new do |entry|
-          entry.title = "#{source.host} linked to #{target.path}"
+          verb = self.english_description(link.type)
+
+          entry.title = "#{source.host} #{verb} #{target.path}"
           entry.id = "#{base_url}/api/mention/#{link.id}"
           entry.updated = link.updated_at
-          entry.summary = "#{source} linked to #{target}"
+          entry.summary = "#{source} #{verb} #{target}"
 
           escaped_source = CGI::escapeHTML(source.to_s)
           escaped_target = CGI::escapeHTML(target.to_s)
-          entry.content = Atom::Content::Xhtml.new("<p><a href=\"#{escaped_source}\">#{escaped_source}</a> linked to <a href=\"#{escaped_target}\">#{escaped_target}</a></p>")
+          entry.content = Atom::Content::Xhtml.new("<p><a href=\"#{escaped_source}\">#{escaped_source}</a> #{verb} <a href=\"#{escaped_target}\">#{escaped_target}</a></p>")
           entry.content.xml_lang = "en"
         end
       end

--- a/helpers/formats.rb
+++ b/helpers/formats.rb
@@ -221,6 +221,7 @@ class Formats
           escaped_source = CGI::escapeHTML(source.to_s)
           escaped_target = CGI::escapeHTML(target.to_s)
           entry.content = Atom::Content::Xhtml.new("<p><a href=\"#{escaped_source}\">#{escaped_source}</a> linked to <a href=\"#{escaped_target}\">#{escaped_target}</a></p>")
+          entry.content.xml_lang = "en"
         end
       end
     }


### PR DESCRIPTION
The format of the links array had changed a bit from what this code expected so I fixed the code. I also made the Atom entries a little more descriptive, so they’ll say e.g. “x bookmarked y” or “x RSVPed ‘yes’ to y” as appropriate.