### PR TITLE
Fix placeholder of input type URL not being a URL.

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -16,7 +16,7 @@
     <div id="web-sign-in">
       <form action="/auth/start" method="get">
         <h3>Web Sign-In</h3>
-        <input type="url" name="me" placeholder="example.com" class="form-control">
+        <input type="url" name="me" placeholder="https://example.com" class="form-control">
         <button class="btn btn-primary btn-large form-control" type="submit">Sign in</button>
       </form>
     </div>


### PR DESCRIPTION
The Web Sign-In input currently has its placeholder attribute set to `example.com` while also having a `type="url"`. This pull request adds `https://` to the placeholder so that people know that a value like `example.com` is not valid.