### PR TITLE
Clarify that the username should be a domain name

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -31,6 +31,8 @@
     &lt;link rel="pingback" href="https://webmention.io/username/xmlrpc" /&gt;</code></pre></p>
 
     <p>The system will begin collecting webmentions and pingbacks on your behalf. Of course you can leave off the pingback endpoint if you'd like.</p>
+
+    <p>Note that the "username" here will most likely be your domain. For instance, if your domain is <code>https://aaronparecki.com/</code>, then your username will be <code>aaronparecki.com</code>.</p>
   </div>
 
 


### PR DESCRIPTION
As found with
https://twitter.com/simonhearne/status/1209053752461795333, it appears
that the documentation could be improved to clarify that the username is
a domain name.