### PR TITLE
Fix overflow on narrow screens

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -59,13 +59,12 @@ a:focus {
 
 .container {
   padding: 0 10px;
-  width: 940px;
+  max-width: 940px;
 }
 
 .container {
   margin-right: auto;
   margin-left: auto;
-  *zoom: 1;
 }
 
 .container:before,


### PR DESCRIPTION
A tiny change to make sure that the webmention.io footer appears correctly on screens (or iframes) of smaller width.

before:
![p.n.o iframe footer now](https://github.com/user-attachments/assets/26f9f3da-6711-451b-8b5e-f04a65a21476)

after:
![p.n.o iframe footer after change](https://github.com/user-attachments/assets/5806d9da-eaf9-45c7-baa0-323561474801)

I also removed the `*zoom` property, which presumably is added as a reminder for a change that never came.